### PR TITLE
Update cookbook links on build page

### DIFF
--- a/src/pages/build.astro
+++ b/src/pages/build.astro
@@ -16,7 +16,7 @@ const resources = [
   [
     {
       title: "Upload your first data",
-      link: "https://cookbook.arweave.net/concepts/post-transactions.html",
+      link: "https://cookbook.arweave.net/guides/posting-transactions/arweave-js.html",
       screenshot: screenUploadData,
     },
     {
@@ -26,7 +26,7 @@ const resources = [
     },
     {
       title: "Use Arweave as a database",
-      link: "https://cookbook.arweave.net/concepts/queryTransactions.html",
+      link: "https://cookbook.arweave.net/guides/graphql/index.html",
       screenshot: screenArweaveAsDb,
     },
     {


### PR DESCRIPTION
This updates the links to the cookbook on the "Build" page to the new paths, so they do not result in a 404 error. 